### PR TITLE
Remove fault contract attribute after generating [#170816361]

### DIFF
--- a/SvcUtilWrapper/Program.cs
+++ b/SvcUtilWrapper/Program.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.IO;
 using System.Net;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using SvcUtilWrapper.Properties;
 
 namespace SvcUtilWrapper
@@ -34,6 +36,8 @@ namespace SvcUtilWrapper
 
                 var svcUtilAssembly = Assembly.LoadFile(svcUtilsPath);
                 svcUtilAssembly.EntryPoint.Invoke(null, new object[] { parameters });
+
+                RemoveFaultContractAttributes();
             }
             catch (Exception e)
             {
@@ -42,6 +46,13 @@ namespace SvcUtilWrapper
             }
 
             Console.WriteLine("Successfully generated client");
+        }
+
+        static void RemoveFaultContractAttributes()
+        {
+            var generated = File.ReadAllText(AppSettings.Default.OutputFilePath);
+            generated = new Regex(@".*\[System.ServiceModel.FaultContractAttribute.*\n").Replace(generated, string.Empty);
+            File.WriteAllText(AppSettings.Default.OutputFilePath, generated);
         }
     }
 }


### PR DESCRIPTION
Purpose:
NetSuite add's additional element in details, so with the FaultContractAttribute we can't handle details, since this attribute requires only one element there. So we will catch it directly and handle it as we want.